### PR TITLE
Fixed cmake version

### DIFF
--- a/Tools/check_cmake.sh
+++ b/Tools/check_cmake.sh
@@ -6,7 +6,7 @@ then
   exit 1;
 fi
 
-if [[ $cmake_ver == *" 2.8"* ]] || [[ $cmake_ver == *" 2.9"* ]] || [[ $cmake_ver == *" 3.0"* ]] || [[ $cmake_ver == *" 3.1"* ]]
+if [[ $cmake_ver == *" 2.8"* ]] || [[ $cmake_ver == *" 2.9"* ]] || [[ $cmake_ver == *" 3.0"* ]] || [[ $cmake_ver =~ 3\.1\D ]]
 then
   exit 1;
 fi


### PR DESCRIPTION
Now detects 3\,1\D meaning 3.1 followed by any non digit or nothing.